### PR TITLE
First checkout declarative-gradle

### DIFF
--- a/.github/workflows/Build.yaml
+++ b/.github/workflows/Build.yaml
@@ -21,7 +21,13 @@ jobs:
     timeout-minutes: 60
 
     steps:
-      - name: Checkout
+      - name: Checkout Declarative Gradle
+        uses: actions/checkout@v4
+        with:
+          repository: 'gradle/declarative-gradle'
+          path: 'declarative-gradle'
+
+      - name: Checkout Now in Android
         uses: actions/checkout@v4
 
       - name: Validate Gradle Wrapper


### PR DESCRIPTION
We want to use an included build on CI, first need to ensure CI checks out the build to include.
