### PR TITLE
Migrate some Android dependency declarations to new more specific sub blocks

### DIFF
--- a/core/common/build.gradle.dcl
+++ b/core/common/build.gradle.dcl
@@ -1,16 +1,18 @@
 androidLibrary {
     namespace = "com.google.samples.apps.nowinandroid.core.common"
 
-    dependencies {
-        testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
-        testImplementation("app.cash.turbine:turbine:1.0.0")
-    }
-
     buildTypes {
         buildTypes {
             // Need the empty closure to avoid "dangling pure expression" error
             debug {}
             release {}
+        }
+    }
+
+    testing {
+        dependencies {
+            testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+            testImplementation("app.cash.turbine:turbine:1.0.0")
         }
     }
 }

--- a/core/common/build.gradle.dcl
+++ b/core/common/build.gradle.dcl
@@ -11,8 +11,8 @@ androidLibrary {
 
     testing {
         dependencies {
-            testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
-            testImplementation("app.cash.turbine:turbine:1.0.0")
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+            implementation("app.cash.turbine:turbine:1.0.0")
         }
     }
 }

--- a/core/data/build.gradle.dcl
+++ b/core/data/build.gradle.dcl
@@ -9,11 +9,6 @@ androidLibrary {
 
         implementation(project(":core:analytics"))
         implementation(project(":core:notifications"))
-
-        testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
-        testImplementation(project(":core:datastore-test"))
-        testImplementation(project(":core:testing"))
-        testImplementation(project(":core:network"))
     }
 
     kotlinSerialization {
@@ -28,6 +23,13 @@ androidLibrary {
     }
 
     testing {
+        dependencies {
+            testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+            testImplementation(project(":core:datastore-test"))
+            testImplementation(project(":core:testing"))
+            testImplementation(project(":core:network"))
+        }
+
         jacoco {
             version = "0.8.7"
         }

--- a/core/data/build.gradle.dcl
+++ b/core/data/build.gradle.dcl
@@ -24,10 +24,10 @@ androidLibrary {
 
     testing {
         dependencies {
-            testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
-            testImplementation(project(":core:datastore-test"))
-            testImplementation(project(":core:testing"))
-            testImplementation(project(":core:network"))
+            implementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.3")
+            implementation(project(":core:datastore-test"))
+            implementation(project(":core:testing"))
+            implementation(project(":core:network"))
         }
 
         jacoco {

--- a/core/domain/build.gradle.dcl
+++ b/core/domain/build.gradle.dcl
@@ -16,7 +16,7 @@ androidLibrary {
 
     testing {
         dependencies {
-            testImplementation(project(":core:testing"))
+            implementation(project(":core:testing"))
         }
 
         jacoco {

--- a/core/domain/build.gradle.dcl
+++ b/core/domain/build.gradle.dcl
@@ -6,8 +6,6 @@ androidLibrary {
 
         api(project(":core:data"))
         api(project(":core:model"))
-
-        testImplementation(project(":core:testing"))
     }
 
     buildTypes {
@@ -17,6 +15,10 @@ androidLibrary {
     }
 
     testing {
+        dependencies {
+            testImplementation(project(":core:testing"))
+        }
+
         jacoco {
             version = "0.8.7"
         }

--- a/feature/bookmarks/build.gradle.dcl
+++ b/feature/bookmarks/build.gradle.dcl
@@ -3,8 +3,6 @@ androidLibrary {
 
     dependencies {
         implementation(project(":core:data"))
-        testImplementation(project(":core:testing"))
-        androidTestImplementation(project(":core:testing"))
     }
 
     feature {
@@ -13,5 +11,12 @@ androidLibrary {
 
     compose {
         description = "Calling the configure method enables compose support"
+    }
+
+    testing {
+        dependencies {
+            testImplementation(project(":core:testing"))
+            androidTestImplementation(project(":core:testing"))
+        }
     }
 }

--- a/feature/bookmarks/build.gradle.dcl
+++ b/feature/bookmarks/build.gradle.dcl
@@ -15,8 +15,8 @@ androidLibrary {
 
     testing {
         dependencies {
-            testImplementation(project(":core:testing"))
-            androidTestImplementation(project(":core:testing"))
+            implementation(project(":core:testing"))
+            androidImplementation(project(":core:testing"))
         }
     }
 }


### PR DESCRIPTION
Requires https://github.com/gradle/declarative-gradle/pull/56

- Migrate testing deps definition to new testing deps block