### PR TITLE
Update to latest gradle nightly

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240614182247+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240703002818+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
The latest gradle nightly allows build-level conventions to be applied in non-declarative scripts that apply software type plugins.