### PR TITLE
Update nightly and rename conventions to defaults

### DIFF
--- a/DECLARATIVE-README.md
+++ b/DECLARATIVE-README.md
@@ -20,7 +20,7 @@ Converted subprojects:
 
 The `androidLibrary` software type exposes [several configuration options](https://github.com/gradle/declarative-gradle/blob/main/unified-prototype/unified-plugin/plugin-android/src/main/java/org/gradle/api/experimental/android/library/AndroidLibrary.java) and dependencies. Test related configuration mimics the existing Android extension for now. 
 
-The [settings file](settings.gradle.dcl) contains several shared conventions that are applied to all subprojects with an `androidLibrary` software type.
+The [settings file](settings.gradle.dcl) contains several shared model defaults that are applied to all subprojects with an `androidLibrary` software type.
 
 Syntax highlighting, code completion and content assist are limited to the latest nightly for Android Studio that understands Gradle DCL files.
 
@@ -75,13 +75,14 @@ After starting a local Android emulator in Android Studio:
 
 Syntax highlighting, code completion and content assist should work in the latest Android Studio nightlies that understand Gradle DCL files.
 
-### Reusable conventions
+### Shared model defaults
 
-The [settings file](settings.gradle.dcl) contains several shared conventions that are applied to all subprojects with an `androidLibrary` software type.  
-Editing these conventions will affect all subprojects.  
-Similarly, changing one of these values in a subproject will override the shared convention.
+The [settings file](settings.gradle.dcl) contains several shared defaults that are applied to all subprojects with an `androidLibrary` software type.  
+The default values configured here are applied to the `androidLibrary` model whenever this software type is added to a subproject.
+Editing these defaults will affect all subprojects.  
+Similarly, changing one of these values in a subproject will override the shared default.
 
 > **NOTE:** In order to avoid applying all configuration from nested blocks such as `kotlinSerialization` or `room` to subprojects
 > where this functionality is unnecessary and perhaps build-breaking, we are using an `enabled=false` flag to **SIMULATE** defining
-> a convention without automatically applying it.  This is **TEMPORARY WORKAROUND** which will ba addressed soon and should not
+> a model default without automatically applying it.  This is **TEMPORARY WORKAROUND** which will ba addressed soon and should not
 > be seen as a pattern to copy.

--- a/app/dependencies/prodReleaseRuntimeClasspath.txt
+++ b/app/dependencies/prodReleaseRuntimeClasspath.txt
@@ -47,6 +47,7 @@ androidx.compose.ui:ui-geometry-android:1.7.0-alpha06
 androidx.compose.ui:ui-geometry:1.7.0-alpha06
 androidx.compose.ui:ui-graphics-android:1.7.0-alpha06
 androidx.compose.ui:ui-graphics:1.7.0-alpha06
+androidx.compose.ui:ui-test-manifest:1.7.0-alpha06
 androidx.compose.ui:ui-text-android:1.7.0-alpha06
 androidx.compose.ui:ui-text:1.7.0-alpha06
 androidx.compose.ui:ui-tooling-preview-android:1.7.0-alpha06

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240703002818+0000-bin.zip
+distributionUrl=https\://services.gradle.org/distributions-snapshots/gradle-8.10-20240719001820+0000-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/settings.gradle.dcl
+++ b/settings.gradle.dcl
@@ -40,7 +40,7 @@ dependencyResolutionManagement {
     }
 }
 
-conventions {
+defaults {
     androidApplication {
         jdkVersion = 11
         compileSdk = 34


### PR DESCRIPTION
Updates to the latest gradle nightly and handles the rename from `conventions` to `defaults`


